### PR TITLE
Making results easier to reason about + memcpy comparison

### DIFF
--- a/decode/Makefile
+++ b/decode/Makefile
@@ -2,11 +2,11 @@
 .PHONY: all clean run
 
 SDE=sde -cnl
-FLAGS_BASE=$(CXXFLAGS) -Wall -Wextra -pedantic -O3 -std=gnu++11
+FLAGS_BASE=$(CXXFLAGS) -Wall -Wextra -pedantic -O3 -std=c++14
 
 HAVE_BMI2=$(shell python script/cpuflags.py bmi2)
 ifeq ($(HAVE_BMI2),present)
-    FLAGS_BASE+=-DHAVE_BMI2_INSTRUCTIONS
+    FLAGS_BASE+=-mbmi2 -DHAVE_BMI2_INSTRUCTIONS
 endif
 
 FLAGS=$(FLAGS_BASE) -msse4 -DHAVE_SSE_INSTRUCTIONS

--- a/decode/application.cpp
+++ b/decode/application.cpp
@@ -1,6 +1,8 @@
 #include "../cmdline.cpp"
+#include "../benchmark.h"
 #include "function_registry.cpp"
 #include "all.cpp"
+#include <cstring>
 
 template <typename Derived>
 class ApplicationBase {
@@ -48,6 +50,7 @@ protected:
         }
 
         fill_input();
+        BEST_TIME(/**/, ::memcpy(output.get(),input.get(),get_input_size()), "memcpy", 1000, count);
 
         initialized = true;
     }

--- a/decode/application.cpp
+++ b/decode/application.cpp
@@ -13,14 +13,13 @@ void* avx512_memcpy(void *dst, const void * src, size_t n) {
       __m512i x = _mm512_loadu_si512((const char*)src + i);
       _mm512_storeu_si512((char*)dst + i, x);
     }
-    if((n%64)!=0) ::memcpy((char*)dst + n - (n%64), (const char*)src + n - (n%64), n%64);
+    size_t leftover = n % 64;
+    ::memcpy((char*)dst + n - leftover, (const char*)src + n - leftover, leftover);
     return dst;
   } else {
     return ::memcpy(dst,src,n);
   }
-
 }
-
 #endif
 
 template <typename Derived>
@@ -60,19 +59,25 @@ protected:
 #if defined(HAVE_AVX512VBMI_INSTRUCTIONS)
         base64::avx512vbmi::prepare_lookups();
 #endif // HAVE_AVX512VBMI_INSTRUCTIONS
-
         input.reset (new uint8_t[get_input_size()]);
         output.reset(new uint8_t[get_output_size() + 64]);
 
         if (!quiet) {
             printf("input size: %lu\n", get_input_size());
+            printf("number of iterations: %u\n", iterations);
+            printf("We report the time in cycles per output byte.\n");
+            printf("For reference, we present the time needed to copy %zu bytes.\n", get_output_size());
         }
 
         fill_input();
-        BEST_TIME(/**/, ::memcpy(output.get(),input.get(),get_output_size()), "memcpy", 1000, count);
+        BEST_TIME(/**/, ::memcpy(output.get(),input.get(),get_output_size()), "memcpy", iterations, get_output_size());
 
 #if defined(HAVE_AVX512_INSTRUCTIONS)
-        BEST_TIME(/**/, avx512_memcpy(output.get(),input.get(),get_output_size()), "memcpy (avx512)", 1000, count);
+        size_t inalign = reinterpret_cast<uintptr_t>(input.get()) & 63;
+        size_t outalign = reinterpret_cast<uintptr_t>(output.get()) & 63;
+        if((inalign !=0) || (outalign!=0))
+          printf("warning: your data pointers are unaligned: %zu %zu\n", inalign, outalign);
+        BEST_TIME(/**/, avx512_memcpy(output.get(),input.get(),get_output_size()), "memcpy (avx512)", iterations, get_output_size());
 #endif
         initialized = true;
     }

--- a/decode/application.cpp
+++ b/decode/application.cpp
@@ -8,10 +8,24 @@
 #include <immintrin.h>
 void* avx512_memcpy(void *dst, const void * src, size_t n) {
   if(n >= 64) {
-    size_t nminus64 = n - 64;
-    for(size_t i = 0; i <= nminus64; i+=64) {
-      __m512i x = _mm512_loadu_si512((const char*)src + i);
-      _mm512_storeu_si512((char*)dst + i, x);
+    size_t i = 0;
+    if(n >= 4*64) {
+      for(; i <= n - 4*64; i+=4*64) {
+        __m512i x0 = _mm512_loadu_si512((const char*)src + i);
+        __m512i x1 = _mm512_loadu_si512((const char*)src + i + 64);
+        __m512i x2 = _mm512_loadu_si512((const char*)src + i + 128);
+        __m512i x3 = _mm512_loadu_si512((const char*)src + i + 192);
+        _mm512_storeu_si512((char*)dst + i, x0);
+        _mm512_storeu_si512((char*)dst + i + 64, x1);
+        _mm512_storeu_si512((char*)dst + i + 128, x2);
+        _mm512_storeu_si512((char*)dst + i + 192, x3);
+     }
+    }
+    if(n>=64) {
+      for(; i <= n - 64; i+=64) {
+        __m512i x0 = _mm512_loadu_si512((const char*)src + i);
+        _mm512_storeu_si512((char*)dst + i, x0);
+      }
     }
     size_t leftover = n % 64;
     ::memcpy((char*)dst + n - leftover, (const char*)src + n - leftover, leftover);

--- a/decode/application.cpp
+++ b/decode/application.cpp
@@ -4,6 +4,25 @@
 #include "all.cpp"
 #include <cstring>
 
+#if defined(HAVE_AVX512_INSTRUCTIONS)
+#include <immintrin.h>
+void* avx512_memcpy(void *dst, const void * src, size_t n) {
+  if(n >= 64) {
+    size_t nminus64 = n - 64;
+    for(size_t i = 0; i <= nminus64; i+=64) {
+      __m512i x = _mm512_loadu_si512((const char*)src + i);
+      _mm512_storeu_si512((char*)dst + i, x);
+    }
+    if((n%64)!=0) ::memcpy((char*)dst + n - (n%64), (const char*)src + n - (n%64), n%64);
+    return dst;
+  } else {
+    return ::memcpy(dst,src,n);
+  }
+
+}
+
+#endif
+
 template <typename Derived>
 class ApplicationBase {
 
@@ -52,6 +71,9 @@ protected:
         fill_input();
         BEST_TIME(/**/, ::memcpy(output.get(),input.get(),get_output_size()), "memcpy", 1000, count);
 
+#if defined(HAVE_AVX512_INSTRUCTIONS)
+        BEST_TIME(/**/, avx512_memcpy(output.get(),input.get(),get_output_size()), "memcpy (avx512)", 1000, count);
+#endif
         initialized = true;
     }
 

--- a/decode/application.cpp
+++ b/decode/application.cpp
@@ -50,7 +50,7 @@ protected:
         }
 
         fill_input();
-        BEST_TIME(/**/, ::memcpy(output.get(),input.get(),get_input_size()), "memcpy", 1000, count);
+        BEST_TIME(/**/, ::memcpy(output.get(),input.get(),get_output_size()), "memcpy", 1000, count);
 
         initialized = true;
     }

--- a/decode/benchmark.cpp
+++ b/decode/benchmark.cpp
@@ -17,7 +17,7 @@ public:
     Application(const CommandLine& c, const FunctionRegistry& r) : super(c, r) {
 
         count      = 4 * 1024; /* override the defaults */
-        iterations = 1000;
+        iterations = 10000;
     }
 
     void run() {

--- a/decode/decode.scalar.cpp
+++ b/decode/decode.scalar.cpp
@@ -1,5 +1,5 @@
 #include <cassert>
-#if defined(HAVE_BMI_INSTRUCTIONS)
+#if defined(HAVE_BMI_INSTRUCTIONS) || defined(HAVE_BMI2_INSTRUCTIONS)
 #   include <x86intrin.h>
 #endif
 
@@ -176,8 +176,12 @@ namespace base64 {
                 // output: [00000000|ddddddcc|ccccbbbb|bbaaaaaa]
 
                 const uint32_t combined = (b0 << (3*8)) | (b1 << (2*8)) | (b2 << (1*8)) | (b3);
-                const uint32_t dword = _bswap(_pext_u32(combined, 0x3f3f3f3f) << 8);
+#ifdef __GNUC__
+                const uint32_t dword = __builtin_bswap32(_pext_u32(combined, 0x3f3f3f3f) << 8);
+#else
 
+                const uint32_t dword = _bswap(_pext_u32(combined, 0x3f3f3f3f) << 8);
+#endif
                 *reinterpret_cast<uint32_t*>(out) = dword;
                 out += 3;
             }

--- a/decode/function_registry.cpp
+++ b/decode/function_registry.cpp
@@ -1,5 +1,7 @@
 #include <unordered_map>
-
+#include <string>
+#include <sstream>
+#include <iostream>
 
 class Function {
 

--- a/encode/Makefile
+++ b/encode/Makefile
@@ -6,7 +6,7 @@ FLAGS_BASE=$(CXXFLAGS) -Wall -Wextra -pedantic -O3
 
 HAVE_BMI2=$(shell python script/cpuflags.py bmi2)
 ifeq ($(HAVE_BMI2),present)
-    FLAGS_BASE+=-DHAVE_BMI2_INSTRUCTIONS
+    FLAGS_BASE+=-mbmi2 -DHAVE_BMI2_INSTRUCTIONS
 endif
 
 FLAGS=$(FLAGS_BASE) -std=c++11 -msse4 -DHAVE_SSE_INSTRUCTIONS

--- a/encode/application.cpp
+++ b/encode/application.cpp
@@ -1,7 +1,9 @@
 #include "../config.h"
+#include "../benchmark.h"
 #include <cstdint>
 #include <cstdlib>
 #include <memory>
+#include <cstring>
 
 #include "encode.scalar.cpp"
 #include "lookup.swar.cpp"
@@ -73,6 +75,7 @@ public:
         printf("input size: %lu\n", get_input_size());
 
         fill_input();
+        BEST_TIME(/**/, ::memcpy(output.get(),input.get(),get_input_size()), "memcpy", 1000, count);
 
         initialized = true;
     }

--- a/encode/application.cpp
+++ b/encode/application.cpp
@@ -48,10 +48,24 @@
 #include <immintrin.h>
 void* avx512_memcpy(void *dst, const void * src, size_t n) {
   if(n >= 64) {
-    size_t nminus64 = n - 64;
-    for(size_t i = 0; i <= nminus64; i+=64) {
-      __m512i x = _mm512_loadu_si512((const char*)src + i);
-      _mm512_storeu_si512((char*)dst + i, x);
+    size_t i = 0;
+    if(n >= 4*64) {
+      for(; i <= n - 4*64; i+=4*64) {
+        __m512i x0 = _mm512_loadu_si512((const char*)src + i);
+        __m512i x1 = _mm512_loadu_si512((const char*)src + i + 64);
+        __m512i x2 = _mm512_loadu_si512((const char*)src + i + 128);
+        __m512i x3 = _mm512_loadu_si512((const char*)src + i + 192);
+        _mm512_storeu_si512((char*)dst + i, x0);
+        _mm512_storeu_si512((char*)dst + i + 64, x1);
+        _mm512_storeu_si512((char*)dst + i + 128, x2);
+        _mm512_storeu_si512((char*)dst + i + 192, x3);
+     }
+    }
+    if(n>=64) {
+      for(; i <= n - 64; i+=64) {
+        __m512i x0 = _mm512_loadu_si512((const char*)src + i);
+        _mm512_storeu_si512((char*)dst + i, x0);
+      }
     }
     size_t leftover = n % 64;
     ::memcpy((char*)dst + n - leftover, (const char*)src + n - leftover, leftover);

--- a/encode/benchmark.cpp
+++ b/encode/benchmark.cpp
@@ -29,7 +29,7 @@ private:
             function(input.get(), get_input_size(), output.get());
         };
 
-        BEST_TIME(, fn(), name, iterations, count);
+        BEST_TIME(, fn(), name, iterations, get_input_size());
     }
 };
 

--- a/encode/benchmark.cpp
+++ b/encode/benchmark.cpp
@@ -29,7 +29,7 @@ private:
             function(input.get(), get_input_size(), output.get());
         };
 
-        BEST_TIME(/**/, fn(), name, iterations, count);
+        BEST_TIME(, fn(), name, iterations, count);
     }
 };
 


### PR DESCRIPTION
It was difficult to determine what the "operation unit" was... I made it explicit. I also added a memcpy reference, which seems essential. The gist of the story seems to be that encoding/encoding is roughly half the speed of a memcpy (if you use a handcrafted naive AVX-512-aware memcpy).

I think we need to worry about alignment. With AVX-512, the registers are the size of a cache line...  If the code was in C, it would be trivial to do an aligned malloc, but in C++, it is less obvious. Still, this should be investigated. There may be noticeable differences.

Numbers below are from a cannonlake microarchitecture.

Encoding speed...

```
$ make ./benchmark_avx512vl && ./benchmark_avx512vl
make: `benchmark_avx512vl' is up to date.
input size: 3072
number of iterations: 10000
We report the time in cycles per input byte.
For reference, we present the time needed to copy 3072 bytes.
rdtsc_overhead set to 20
memcpy                        	:     0.045 cycle/op (best)    0.046 cycle/op (avg)
warning: your data pointers are unaligned: 16 32
memcpy (avx512)               	:     0.024 cycle/op (best)    0.027 cycle/op  #(avg)
AVX512VBMI                    	:     0.051 cycle/op (best)    0.053 cycle/op (avg)
AVX512VL                      	:     0.045 cycle/op (best)    0.046 cycle/op (avg)
```


Decoding...
```
$ make ./benchmark_avx512vbmi && ./benchmark_avx512vbmi
g++  -Wall -Wextra -pedantic -O3 -std=c++14 -mbmi2 -DHAVE_BMI2_INSTRUCTIONS -mavx512vbmi -mbmi2 -DHAVE_AVX512VBMI_INSTRUCTIONS -DHAVE_BMI2_INSTRUCTIONS  benchmark.cpp -o benchmark_avx512vbmi
input size: 4096
number of iterations: 10000
We report the time in cycles per output byte.
For reference, we present the time needed to copy 3072 bytes.
rdtsc_overhead set to 20
memcpy                        	:     0.046 cycle/op (best)    0.047 cycle/op (avg)
warning: your data pointers are unaligned: 32 48
memcpy (avx512)               	:     0.025 cycle/op (best)    0.026 cycle/op (avg)
...
AVX512VBMI (lookup: N/A, pack: multiply-add)	:     0.060 cycle/op (best)    0.063 cycle/op (avg)
```