### PR TITLE
Add Base64 encoding implementation 

### DIFF
--- a/encode/application.cpp
+++ b/encode/application.cpp
@@ -427,6 +427,14 @@ protected:
             };
             run_function("RISC-V Vector (LMUL=8, strided load, gather)", fun);
         }
+
+        if (can_run("rvv", "rvv/5")) {
+            auto fun = [](const uint8_t* input, size_t bytes, uint8_t* output) {
+                using namespace base64::rvv;
+                encode_option(lookup_option, input, bytes, output);
+            };
+            run_function("RISC-V Vector (LMUL=4, vmul/h shifting, gather)", fun);
+        }
 #endif
     }
 

--- a/encode/encode.rvv.cpp
+++ b/encode/encode.rvv.cpp
@@ -213,8 +213,6 @@ namespace base64 {
 
                 vl = __riscv_vsetvlmax_e32m4();
 
-                // vuint32m4_t vec_lookup_indices = lookup_m4(vec_gather, vl);
-
                 vuint32m4_t input32 = __riscv_vreinterpret_v_u8m4_u32m4(vec_gather);
 
                 // mask out so that only a and c bits remain
@@ -236,8 +234,6 @@ namespace base64 {
 
                 vl = __riscv_vsetvlmax_e8m4();
 
-                // two different ways to calculate the lookup step
-                // vuint8m4_t base64_chars = __riscv_vluxei8_v_u8m4(b64chars, __riscv_vreinterpret_v_u32m4_u8m4(vec_lookup_indices), vl);
                 const vuint8m4_t base64_chars = lookup(__riscv_vreinterpret_v_u32m4_u8m4(vec_lookup_indices), vl);
 
                 __riscv_vse8_v_u8m4((uint8_t *)output, base64_chars, vl);

--- a/encode/encode.rvv.cpp
+++ b/encode/encode.rvv.cpp
@@ -163,6 +163,92 @@ namespace base64 {
             base64::scalar::encode32(input, bytes, out);
         }
 
+        template <typename LOOKUP_FN>
+        void encode_option(LOOKUP_FN lookup, const uint8_t *input, size_t bytes, uint8_t *output)
+        {
+            size_t vl;
+
+            size_t vlmax_e8m4 = __riscv_vsetvlmax_e8m4();
+            size_t vlmax_e8m1 = __riscv_vsetvlmax_e8m1();
+            size_t vlmax_e32m4 = __riscv_vsetvlmax_e32m4();
+
+            const vuint8m1_t vec_index_e8m1 = __riscv_vle8_v_u8m1(gather_index_lmul4, vlmax_e8m1);
+
+            size_t input_slice_e8m4 = (vlmax_e8m4 / 4) * 3;
+            size_t input_slice_e8m1 = (vlmax_e8m1 / 4) * 3;
+
+            const vuint32m4_t const_vec_ac = __riscv_vmv_v_x_u32m4(0x04000040, vlmax_e32m4);
+            const vuint32m4_t const_vec_bd = __riscv_vmv_v_x_u32m4(0x01000010, vlmax_e32m4);
+
+            for (; bytes >= input_slice_e8m4; bytes -= input_slice_e8m4)
+            {
+
+                vl = __riscv_vsetvl_e8m1(input_slice_e8m1);
+
+                /**
+                 * Load (vlmax_e8m1 / 4) * 3 elements into each vector register.
+                 */
+                vuint8m1_t vec_input_0 = __riscv_vle8_v_u8m1(input, vl);
+                input += (vlmax_e8m1 / 4) * 3;
+
+                vuint8m1_t vec_input_1 = __riscv_vle8_v_u8m1(input, vl);
+                input += (vlmax_e8m1 / 4) * 3;
+
+                vuint8m1_t vec_input_2 = __riscv_vle8_v_u8m1(input, vl);
+                input += (vlmax_e8m1 / 4) * 3;
+
+                vuint8m1_t vec_input_3 = __riscv_vle8_v_u8m1(input, vl);
+
+                vl = __riscv_vsetvl_e8m1(vlmax_e8m1);
+
+                //  the vrgather operation is cheaper at lmul=1 (4*4=16 cycles) than at lmul=4 (64 cycles), therefore each register gets shuffled seperately (https://camel-cdr.github.io/rvv-bench-results/bpi_f3/index.html)
+                vuint8m1_t vec_gather_0 = __riscv_vrgather_vv_u8m1(vec_input_0, vec_index_e8m1, vl);
+                vuint8m1_t vec_gather_1 = __riscv_vrgather_vv_u8m1(vec_input_1, vec_index_e8m1, vl);
+                vuint8m1_t vec_gather_2 = __riscv_vrgather_vv_u8m1(vec_input_2, vec_index_e8m1, vl);
+                vuint8m1_t vec_gather_3 = __riscv_vrgather_vv_u8m1(vec_input_3, vec_index_e8m1, vl);
+
+                vuint8m4_t vec_gather = __riscv_vcreate_v_u8m1_u8m4(vec_gather_0, vec_gather_1, vec_gather_2, vec_gather_3);
+
+                vl = __riscv_vsetvlmax_e32m4();
+
+                // vuint32m4_t vec_lookup_indices = lookup_m4(vec_gather, vl);
+
+                vuint32m4_t input32 = __riscv_vreinterpret_v_u8m4_u32m4(vec_gather);
+
+                // mask out so that only a and c bits remain
+                vuint32m4_t index_a_c = __riscv_vand_vx_u32m4(input32, 0x0FC0FC00, vl);
+
+                // mask out so that only a and c bits remain
+                vuint32m4_t index_b_d = __riscv_vand_vx_u32m4(input32, 0x003F03F0, vl);
+
+                vl = __riscv_vsetvlmax_e16m4();
+                // multiply 16-bit integers and store high 16 bits of 32-bit result
+                vuint16m4_t vec_shifted_ac = __riscv_vmulhu_vv_u16m4(__riscv_vreinterpret_v_u32m4_u16m4(index_a_c), __riscv_vreinterpret_v_u32m4_u16m4(const_vec_ac), vl);
+
+                // multiply 16-bit integers and store low 16 bits of 32-bit result
+                vuint16m4_t vec_shifted_bd = __riscv_vmul_vv_u16m4(__riscv_vreinterpret_v_u32m4_u16m4(index_b_d), __riscv_vreinterpret_v_u32m4_u16m4(const_vec_bd), vl);
+
+                vl = __riscv_vsetvlmax_e32m4();
+
+                vuint32m4_t vec_lookup_indices = __riscv_vor_vv_u32m4(__riscv_vreinterpret_v_u16m4_u32m4(vec_shifted_ac), __riscv_vreinterpret_v_u16m4_u32m4(vec_shifted_bd), vl);
+
+                vl = __riscv_vsetvlmax_e8m4();
+
+                // two different ways to calculate the lookup step
+                // vuint8m4_t base64_chars = __riscv_vluxei8_v_u8m4(b64chars, __riscv_vreinterpret_v_u32m4_u8m4(vec_lookup_indices), vl);
+                const vuint8m4_t base64_chars = lookup(__riscv_vreinterpret_v_u32m4_u8m4(vec_lookup_indices), vl);
+
+                __riscv_vse8_v_u8m4((uint8_t *)output, base64_chars, vl);
+
+                input += (vlmax_e8m1 / 4) * 3;
+
+                output += vlmax_e8m4;
+            }
+
+            // scalar fallback
+            base64::scalar::encode32(input, bytes, output);
+        }
+
         // GCC 13.2.0 lacks support for the lastest intrinsics standard, thus
         // this inline asm implementation.
         void encode_loadseg(const uint8_t* input, size_t bytes, uint8_t* output) {

--- a/encode/encode.rvv.cpp
+++ b/encode/encode.rvv.cpp
@@ -172,6 +172,8 @@ namespace base64 {
             size_t vlmax_e8m1 = __riscv_vsetvlmax_e8m1();
             size_t vlmax_e32m4 = __riscv_vsetvlmax_e32m4();
 
+            const uint8_t gather_index_lmul4[32] = {1, 0, 2, 1, 4, 3, 5, 4, 7, 6, 8, 7, 10, 9, 11, 10, 13, 12, 14, 13, 16, 15, 17, 16, 19, 18, 20, 19, 22, 21, 23, 22};
+
             const vuint8m1_t vec_index_e8m1 = __riscv_vle8_v_u8m1(gather_index_lmul4, vlmax_e8m1);
 
             size_t input_slice_e8m4 = (vlmax_e8m4 / 4) * 3;

--- a/encode/lookup.rvv.cpp
+++ b/encode/lookup.rvv.cpp
@@ -64,6 +64,30 @@ namespace base64 {
             return __riscv_vrgather_vv_u8m8(lookup, indices, vl);
         }
 
+        vuint8m4_t lookup_option(vuint8m4_t indices, size_t /*unused*/)
+        {
+
+            vint8m1_t offset_vec = __riscv_vle8_v_i8m1(offsets, __riscv_vsetvlmax_e8m1());
+
+            size_t vl = __riscv_vsetvlmax_e8m4();
+            // reduce values 0-64 to 0-13
+            vuint8m4_t result = __riscv_vssubu_vx_u8m4(indices, 51, vl);
+            vbool2_t vec_lt_26 = __riscv_vmsltu_vx_u8m4_b2(indices, 26, vl);
+            const vuint8m4_t vec_lookup = __riscv_vadd_vx_u8m4_mu(vec_lt_26, result, result, 13, vl);
+
+            // shuffle registers one by one
+            vint8m1_t offset_vec_0 = __riscv_vrgather_vv_i8m1(offset_vec, __riscv_vget_v_u8m4_u8m1(vec_lookup, 0), vl);
+            vint8m1_t offset_vec_1 = __riscv_vrgather_vv_i8m1(offset_vec, __riscv_vget_v_u8m4_u8m1(vec_lookup, 1), vl);
+            vint8m1_t offset_vec_2 = __riscv_vrgather_vv_i8m1(offset_vec, __riscv_vget_v_u8m4_u8m1(vec_lookup, 2), vl);
+            vint8m1_t offset_vec_3 = __riscv_vrgather_vv_i8m1(offset_vec, __riscv_vget_v_u8m4_u8m1(vec_lookup, 3), vl);
+
+            vint8m4_t offset_vec_bundle = __riscv_vcreate_v_i8m1_i8m4(offset_vec_0, offset_vec_1, offset_vec_2, offset_vec_3);
+
+            vint8m4_t ascii_vec = __riscv_vadd_vv_i8m4(__riscv_vreinterpret_v_u8m4_i8m4(indices), offset_vec_bundle, vl);
+
+            return __riscv_vreinterpret_v_i8m4_u8m4(ascii_vec);
+        }
+
     } // namespace rvv
 
 } // namespace base64

--- a/encode/lookup.rvv.cpp
+++ b/encode/lookup.rvv.cpp
@@ -66,6 +66,7 @@ namespace base64 {
 
         vuint8m4_t lookup_option(vuint8m4_t indices, size_t /*unused*/)
         {
+            const int8_t offsets[68] = {71, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -19, -16, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
             vint8m1_t offset_vec = __riscv_vle8_v_i8m1(offsets, __riscv_vsetvlmax_e8m1());
 

--- a/encode/lookup.rvv.cpp
+++ b/encode/lookup.rvv.cpp
@@ -64,13 +64,13 @@ namespace base64 {
             return __riscv_vrgather_vv_u8m8(lookup, indices, vl);
         }
 
-        vuint8m4_t lookup_option(vuint8m4_t indices, size_t /*unused*/)
+        vuint8m4_t lookup_option(vuint8m4_t indices, size_t vl)
         {
             const int8_t offsets[68] = {71, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -19, -16, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-            vint8m1_t offset_vec = __riscv_vle8_v_i8m1(offsets, __riscv_vsetvlmax_e8m1());
+            vint8m1_t offset_vec = __riscv_vle8_v_i8m1(offsets, vl);
 
-            size_t vl = __riscv_vsetvlmax_e8m4();
+            vl = __riscv_vsetvlmax_e8m4();
             // reduce values 0-64 to 0-13
             vuint8m4_t result = __riscv_vssubu_vx_u8m4(indices, 51, vl);
             vbool2_t vec_lt_26 = __riscv_vmsltu_vx_u8m4_b2(indices, 26, vl);

--- a/encode/verify.cpp
+++ b/encode/verify.cpp
@@ -645,6 +645,14 @@ void validate_encoding() {
 
     {
         auto fn = [](const uint8_t* input, size_t bytes, uint8_t* output) {
+            base64::rvv::encode_option(base64::rvv::lookup_option, input, bytes, output);
+        };
+
+        validate_encoding("RISC-V Vector (LMUL=4, vmulh shifting, gather)", fn);
+    }
+
+    {
+        auto fn = [](const uint8_t* input, size_t bytes, uint8_t* output) {
             base64::rvv::encode_strided_load_m8(base64::rvv::lookup_wide_gather, input, bytes, output);
         };
 


### PR DESCRIPTION
This pull request introduces a new Base64 encoding implementation leveraging `LMUL=4` and `vmul/h` instructions for index shifting, along with a gather table lookup method. Initial benchmarks using the [Base64 Benchmark suite](https://github.com/vogma/base64_benchmark/tree/base64rvv) indicate good performance on my Milk-V Jupiter SBC, but I want to compare my implementation to the ones present in this repository.

Unfortunately, when building the verify executable, to only vectorized implementation passing the tests are (LMUL=4, segmented load, gather) and my implementation.

On my Milk-V Jupiter, i got the following results for my implementation:
```
RISC-V Vector (LMUL=4, vmul/h shifting, gather)	:     1.587 cycle/op (best)    1.600 cycle/op (avg)
``` 
All other benchmarks crashed when the executable called free() on the allocated encoding memory.

